### PR TITLE
cmd/doc: redirect legacy /github.com URLs to new /repo/github.com

### DIFF
--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -857,6 +857,11 @@ func org(w http.ResponseWriter, r *http.Request) {
 func doc(w http.ResponseWriter, r *http.Request) {
 	rest, ok := strings.CutPrefix(r.URL.Path, "/repo")
 	if !ok {
+		if strings.HasPrefix(r.URL.Path, "/github.com") {
+			http.Redirect(w, r, "/repo"+r.URL.Path, http.StatusMovedPermanently)
+			return
+		}
+
 		http.Error(w, "Invalid URL.", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
The /github.com URLs were in the old (pre-fork) version. I had moved everything over with the hopes of eventually supporting non-github.com URLs. In the meanwhile, I should avoid breaking those legacy paths.