### PR TITLE
Fall back to text when highlighting unknown languages

### DIFF
--- a/template/doc.html
+++ b/template/doc.html
@@ -35,6 +35,10 @@
     marked.use({
         renderer: {
             code: (code, lang, escaped) => {
+                if(window.Prism && !Prism.languages[lang]) {
+                    lang = 'text';
+                }
+
                 const tokenizedCode = window.Prism ? Prism.highlight(code, Prism.languages[lang], lang) : `${code}`;
                 return `<pre class="language-${lang}"><code class="language-${lang}">${tokenizedCode}</code></pre>`;
             }


### PR DESCRIPTION
Addresses https://github.com/crdsdev/doc/issues/182

I tested this locally against the CRD mentioned in that issue, so this _should_ work!